### PR TITLE
Link auf fhir.org korrigiert

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This GITHUB repository is the source content for the [German XDS ValueSet publication](http://www.ihe-d.de/fhir/ImplementationGuide/ihe.iti.de.xds-vs) 
 by IHE Germany. 
 
-This Continuous Build will appear at http://build.fhir.org/ig/IHE-Germany/ITI.XDS.VS/branches/master/index.html.
+This Continuous Build will appear at https://build.fhir.org/ig/IHE-Germany/ITI.XDS.VS.
 
 It is currently the initial draft and it is expected to have updates soon.
 For the moment, we are seeing forward to get feedback on possible errors:


### PR DESCRIPTION
Mein erster Versuch konstruktiv zuzuarbeiten. Der Link zeigte bisher ins Leere und nutzte kein TLS.