### PR TITLE
CS OIDs hinzugefügt/korrigiert; QualifikationÄrztekammer ersetzt

### DIFF
--- a/input/fsh/authorRole.fsh
+++ b/input/fsh/authorRole.fsh
@@ -17,6 +17,10 @@ Description: "**Patientenbeziehungsrollen** für Autoren"
 * ^versionNeeded = false
 * ^content = #complete
 
+* ^identifier.system = "urn:ietf:rfc:3986"
+* ^identifier.value = "urn:oid:1.3.6.1.4.1.19376.3.276.1.5.14"
+* ^identifier.use = #official
+
 * ^extension[0].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm"
 * ^extension[=].valueInteger = 2
 * ^extension[=].valueInteger.extension.url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-conformance-derivedFrom"
@@ -105,6 +109,10 @@ Description: "**Prozessrollen** für Autoren"
 
 * insert HeaderDetailRules
 
+* ^identifier.system = "urn:ietf:rfc:3986"
+* ^identifier.value = "urn:oid:1.3.6.1.4.1.19376.3.276.1.5.13"
+* ^identifier.use = #official
+
 * ^property[+].code = #parent
 * ^property[=].uri = "http://hl7.org/fhir/concept-properties#parent"
 * ^property[=].description = "Who is the parent element of this concept? Multiple parents are possible."
@@ -183,7 +191,9 @@ Description: "**IHE XDS Author Role**"
 * include codes from system http://www.ihe-d.de/fhir/CodeSystem/ProzessrollenFuerAutoren
 * include codes from system http://www.ihe-d.de/fhir/CodeSystem/PatientenbeziehungsrollenFuerAutoren
 
-
+* ^identifier.system = "urn:ietf:rfc:3986"
+* ^identifier.value = "urn:oid:1.2.276.0.76.11.30"
+* ^identifier.use = #official
 
 Instance: AuthorRole
 InstanceOf: NamingSystem

--- a/input/fsh/authorSpecialty.fsh
+++ b/input/fsh/authorSpecialty.fsh
@@ -235,22 +235,26 @@ Description: "**Facharzttitel Ärztekammer**"
 
 //CodeSystem
 
-CodeSystem: QualifikationenAerztekammer
-Id: QualifikationenAerztekammer
+CodeSystem: QualifikationenNichtaerztlicherAutoren
+Id: QualifikationenNichtaerztlicherAutoren
 Title: "Qualifikationen nicht ärztlicher Autoren"
 Description: "**Qualifikationen nicht ärztlicher Autoren**"
 
-* ^url = "http://www.ihe-d.de/fhir/CodeSystem/QualifikationenAerztekammer"
+* ^url = "http://www.ihe-d.de/fhir/CodeSystem/QualifikationenNichtaerztlicherAutoren"
 * ^version = "4.0.0-alpha0"
 
 * insert HeaderDetailRules
 
 * ^caseSensitive = false
-* ^valueSet = "http://www.ihe-d.de/fhir/ValueSet/QualifikationenAerztekammer"
+* ^valueSet = "http://www.ihe-d.de/fhir/ValueSet/QualifikationenNichtaerztlicherAutoren"
 * ^hierarchyMeaning = #is-a
 * ^compositional = false
 * ^versionNeeded = false
 * ^content = #complete
+
+* ^identifier.system = "urn:ietf:rfc:3986"
+* ^identifier.value = "urn:oid:1.3.6.1.4.1.19376.3.276.1.5.11"
+* ^identifier.use = #official
 
 * ^property[+].code = #status
 * ^property[=].uri = "http://hl7.org/fhir/concept-properties#status"
@@ -830,17 +834,17 @@ Description: "**Qualifikationen nicht ärztlicher Autoren**"
 
 //ValueSet
 
-ValueSet: QualifikationenAerztekammer
-Id: QualifikationenAerztekammer
-Title: "Qualifikationen Ärztekammer"
-Description: "**Qualifikationen Ärztekammer**"
+ValueSet: QualifikationenNichtaerztlicherAutoren
+Id: QualifikationenNichtaerztlicherAutoren
+Title: "Qualifikationen nicht ärztlicher Autoren"
+Description: "**Qualifikationen nicht ärztlicher Autoren**"
 
-* ^url = "http://www.ihe-d.de/fhir/ValueSet/QualifikationenAerztekammer"
+* ^url = "http://www.ihe-d.de/fhir/ValueSet/QualifikationenNichtaerztlicherAutoren"
 * ^version = "4.0.0-alpha0"
 
 * insert HeaderDetailRules
 
-* include codes from system http://www.ihe-d.de/fhir/CodeSystem/QualifikationenAerztekammer
+* include codes from system http://www.ihe-d.de/fhir/CodeSystem/QualifikationenNichtaerztlicherAutoren
 
 
 //CodeSystem
@@ -861,6 +865,10 @@ Description: "**Qualifikatoren zahnärztlicher Autoren**"
 * ^compositional = false
 * ^versionNeeded = false
 * ^content = #complete
+
+* ^identifier.system = "urn:ietf:rfc:3986"
+* ^identifier.value = "urn:oid:1.2.276.0.76.5.492"
+* ^identifier.use = #official
 
 * ^property[+].code = #parent
 * ^property[=].uri = "http://hl7.org/fhir/concept-properties#parent"
@@ -920,6 +928,10 @@ Description: "**Ärztliche Berufsvarianten**"
 * ^versionNeeded = false
 * ^content = #complete
 
+* ^identifier.system = "urn:ietf:rfc:3986"
+* ^identifier.value = "urn:oid:1.2.276.0.76.5.493"
+* ^identifier.use = #official
+
 * ^property[+].code = #status
 * ^property[=].uri = "http://hl7.org/fhir/concept-properties#status"
 * ^property[=].description = "Status"
@@ -965,7 +977,7 @@ Description: "**IHE XDS Author Specialty**"
 * insert HeaderDetailRules
 
 * include codes from system http://www.ihe-d.de/fhir/CodeSystem/FacharzttitelAerztekammer
-* include codes from system http://www.ihe-d.de/fhir/CodeSystem/QualifikationenAerztekammer
+* include codes from system http://www.ihe-d.de/fhir/CodeSystem/QualifikationenNichtaerztlicherAutoren
 * include codes from system http://www.ihe-d.de/fhir/CodeSystem/QualifikatorenZahnAerztekammer
 * include codes from system http://www.ihe-d.de/fhir/CodeSystem/AerztlicheBerufe
 

--- a/input/fsh/practiceSettingDoctoral.fsh
+++ b/input/fsh/practiceSettingDoctoral.fsh
@@ -17,6 +17,10 @@ Description: "**Ärztliche Fachrichtungen** (Practice Setting Doctoral)"
 * ^versionNeeded = false
 * ^content = #complete
 
+* ^identifier.system = "urn:ietf:rfc:3986"
+* ^identifier.value = "urn:oid:1.3.6.1.4.1.19376.3.276.1.5.4"
+* ^identifier.use = #official
+
 * ^property[0].code = #status
 * ^property[=].uri = "http://hl7.org/fhir/concept-properties#status"
 * ^property[=].description = "Status"
@@ -225,7 +229,7 @@ Description: "**Practice Setting Doctoral** (Ärztliche Fachrichtungen)"
 * insert HeaderDetailRules
 
 * ^identifier.system = "urn:ietf:rfc:3986"
-* ^identifier.value = "urn:oid:1.3.6.1.4.1.19376.3.276.1.5.4"
+* ^identifier.value = "urn:oid:1.2.276.0.76.11.69"
 * ^identifier.use = #official
 
 * include codes from system http://www.ihe-d.de/fhir/CodeSystem/AerztlicheFachrichtungen

--- a/input/fsh/practiceSettingNonDoctoral.fsh
+++ b/input/fsh/practiceSettingNonDoctoral.fsh
@@ -17,6 +17,10 @@ Description: "**Nicht-ärztliche Fachrichtungen** (Practice Setting Non Doctoral
 * ^versionNeeded = false
 * ^content = #complete
 
+* ^identifier.system = "urn:ietf:rfc:3986"
+* ^identifier.value = "urn:oid:1.3.6.1.4.1.19376.3.276.1.5.5"
+* ^identifier.use = #official
+
 * ^property.code = #parent
 * ^property.uri = "http://hl7.org/fhir/concept-properties#parent"
 * ^property.description = "Who is the parent element of this concept? Multiple parents are possible."
@@ -56,7 +60,7 @@ Description: "**Practice Setting Non Doctoral** (Nicht-ärztliche Fachrichtungen
 * insert HeaderDetailRules
 
 * ^identifier.system = "urn:ietf:rfc:3986"
-* ^identifier.value = "urn:oid:1.3.6.1.4.1.19376.3.276.1.5.5"
+* ^identifier.value = "urn:oid:1.2.276.0.76.11.70"
 * ^identifier.use = #official
 
 * include codes from system http://www.ihe-d.de/fhir/CodeSystem/NichtaerztlicheFachrichtungen

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -162,7 +162,7 @@ menu:
     Ordnertypen: CodeSystem-Ordnertypen.html
     Patientenbeziehungsrollen für Autoren: CodeSystem-PatientenbeziehungsrollenFuerAutoren.html
     Prozessrollen für Autoren: CodeSystem-ProzessrollenFuerAutoren.html
-    Qualifikationen Ärztekammer: CodeSystem-QualifikationenAerztekammer.html
+    Qualifikationen Ärztekammer: CodeSystem-QualifikationenNichtaerztlicherAutoren.html
     Qualifikatoren zahnärztlicher Autoren: CodeSystem-QualifikatorenZahnAerztekammer.html
     Vertraulichkeiten: CodeSystem-Vertraulichkeiten.html
   Value Sets:
@@ -181,7 +181,7 @@ menu:
     Ordnertypen: ValueSet-Ordnertypen.html
     Patientenbeziehungsrollen für Autoren: ValueSet-PatientenbeziehungsrollenFuerAutoren.html
     Prozessrollen für Autoren: ValueSet-ProzessrollenFuerAutoren.html
-    Qualifikationen Ärztekammer: ValueSet-QualifikationenAerztekammer.html
+    Qualifikationen Ärztekammer: ValueSet-QualifikationenNichtaerztlicherAutoren.html
     Qualifikatoren zahnärztlicher Autoren: CodeSystem-QualifikatorenZahnAerztekammer.html
     Vertraulichkeiten: ValueSet-Vertraulichkeiten.html
   Naming Systems: artifacts.html#terminology-naming-systems


### PR DESCRIPTION
Ergebnis des IHE DE VS Arbeitsgruppen-Meetings vom 07.06.24
- OIDs hinzugefügt für Author CodeSysteme
- OIDs hinzugefügt für PracticeSetting CodeSysteme und korrigiert für die ValueSets
- QualifikationÄrztekammer vollständig ersetzt durch QualifikationNichtarztlicherAutoren (vorher liefen der Titel und die URL auseinander), wir haben jetzt den Titel als Grundlage genommen (auch da die Ärztekammern bei diesem CodeSystem nicht involviert waren)